### PR TITLE
fix(link): [SFEQS-1634] Use x-forwarded-host for building links

### DIFF
--- a/src/__test__/app.spec.ts
+++ b/src/__test__/app.spec.ts
@@ -96,7 +96,7 @@ describe("/qrcode.png", () => {
   it<AppTestContext>("should return a 200 with a QRCODE image in png when payload is valid", async (ctx) => {
     const res = await supertest(ctx.app)
       .get(`${ctx.endpoint}?feat=firma&srid=SIGNATUREID`)
-      .set("Host", "localhost:1407")
+      .set("X-Forwarded-Host", "localhost:1407")
       .expect(200);
     expect(res.headers["content-type"]).toContain("image/png");
     // Since this is a test executed in an async context, we have to use "expect" from the context
@@ -117,7 +117,7 @@ describe("/open", () => {
   it<AppTestContext>("should redirect to link when payload is valid", async (ctx) => {
     await supertest(ctx.app)
       .get(`${ctx.endpoint}?feat=firma&srid=SIGNATUREID`)
-      .set("Host", "localhost:1407")
+      .set("X-Forwarded-Host", "localhost:1407")
       .expect(302)
       .expect(
         "Location",

--- a/src/app.ts
+++ b/src/app.ts
@@ -83,7 +83,7 @@ export const createApp = (
         payload,
       });
       // The UNIVERSAL LINK should have https scheme
-      const link = buildLink(`https://${req.get("host")}`, payload);
+      const link = buildLink(`https://${req.get("x-forwarded-host")}`, payload);
       req.log?.("debug", "link created", {
         link,
       });
@@ -109,7 +109,7 @@ export const createApp = (
       req.log?.("debug", "parsed payload", {
         payload,
       });
-      const link = buildLink(`https://${req.get("host")}`, payload);
+      const link = buildLink(`https://${req.get("x-forwarded-host")}`, payload);
       req.log?.("debug", "link created", {
         link,
       });


### PR DESCRIPTION
When building link, get the hostname from the `X-Forwarded-Host` header